### PR TITLE
질의응답 기능 구현

### DIFF
--- a/src/main/java/com/igloo_club/nungil_v3/controller/QuestionAndAnswerController.java
+++ b/src/main/java/com/igloo_club/nungil_v3/controller/QuestionAndAnswerController.java
@@ -1,0 +1,93 @@
+package com.igloo_club.nungil_v3.controller;
+
+import com.igloo_club.nungil_v3.domain.Member;
+import com.igloo_club.nungil_v3.domain.enums.Question;
+import com.igloo_club.nungil_v3.domain.enums.QuestionCategory;
+import com.igloo_club.nungil_v3.dto.QuestionAndAnswerCreateRequest;
+import com.igloo_club.nungil_v3.dto.QuestionAndAnswerResponse;
+import com.igloo_club.nungil_v3.dto.QuestionAndAnswerUpdateRequest;
+import com.igloo_club.nungil_v3.dto.QuestionListResponse;
+import com.igloo_club.nungil_v3.service.MemberService;
+import com.igloo_club.nungil_v3.service.QuestionAndAnswerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/questions")
+public class QuestionAndAnswerController {
+
+    private final QuestionAndAnswerService questionAndAnswerService;
+
+    private final MemberService memberService;
+    @PostMapping
+    public ResponseEntity<?> createQuestionAndAnswer(
+            @RequestBody QuestionAndAnswerCreateRequest request,
+            Principal principal) {
+
+        Member member = getMember(principal);
+
+        questionAndAnswerService.createQuestionAndAnswer(request, member);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PatchMapping("/{qaId}")
+    public ResponseEntity<?> updateQuestionAndAnswer(
+            @RequestBody QuestionAndAnswerUpdateRequest request,
+            @PathVariable Long qaId,
+            Principal principal) {
+
+        Member member = getMember(principal);
+
+        questionAndAnswerService.updateQuestionAndAnswer(qaId, request, member);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/{question}")
+    public ResponseEntity<?> getQuestionAndAnswer(
+            @PathVariable Question question,
+            Principal principal) {
+
+        Member member = getMember(principal);
+
+        QuestionAndAnswerResponse response = questionAndAnswerService.getQuestionAndAnswerResponseByMemberAndQuestion(member, question);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/exposing")
+    public ResponseEntity<Slice<QuestionAndAnswerResponse>> getExposingQuestionAndAnswerPageByMember(
+            @RequestParam int page,
+            @RequestParam int size,
+            Principal principal) {
+
+        Member member = getMember(principal);
+
+        Slice<QuestionAndAnswerResponse> response = questionAndAnswerService.getExposingQuestionAndAnswerPageByMember(member, page, size);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/category/{category}")
+    public ResponseEntity<Slice<QuestionListResponse>> getQuestionList(
+            @PathVariable QuestionCategory category,
+            @RequestParam int page,
+            @RequestParam int size,
+            Principal principal) {
+
+        // 멤버 조회 로직 추가
+        Member member = getMember(principal);
+
+        Slice<QuestionListResponse> response = questionAndAnswerService.getQuestionList(member, category, page, size);
+        return ResponseEntity.ok(response);
+    }
+
+
+    private Member getMember(Principal principal) {
+        return memberService.findById(Long.parseLong(principal.getName()));
+    }
+}

--- a/src/main/java/com/igloo_club/nungil_v3/controller/QuestionAndAnswerController.java
+++ b/src/main/java/com/igloo_club/nungil_v3/controller/QuestionAndAnswerController.java
@@ -48,14 +48,11 @@ public class QuestionAndAnswerController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @GetMapping("/{question}")
+    @GetMapping("/{qaId}")
     public ResponseEntity<?> getQuestionAndAnswer(
-            @PathVariable Question question,
-            Principal principal) {
+            @PathVariable Long qaId) {
 
-        Member member = getMember(principal);
-
-        QuestionAndAnswerResponse response = questionAndAnswerService.getQuestionAndAnswerResponseByMemberAndQuestion(member, question);
+        QuestionAndAnswerResponse response = questionAndAnswerService.getQuestionAndAnswerResponseByMemberAndQuestion(qaId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/igloo_club/nungil_v3/controller/QuestionAndAnswerController.java
+++ b/src/main/java/com/igloo_club/nungil_v3/controller/QuestionAndAnswerController.java
@@ -1,7 +1,6 @@
 package com.igloo_club.nungil_v3.controller;
 
 import com.igloo_club.nungil_v3.domain.Member;
-import com.igloo_club.nungil_v3.domain.enums.Question;
 import com.igloo_club.nungil_v3.domain.enums.QuestionCategory;
 import com.igloo_club.nungil_v3.dto.QuestionAndAnswerCreateRequest;
 import com.igloo_club.nungil_v3.dto.QuestionAndAnswerResponse;

--- a/src/main/java/com/igloo_club/nungil_v3/domain/QuestionAndAnswer.java
+++ b/src/main/java/com/igloo_club/nungil_v3/domain/QuestionAndAnswer.java
@@ -2,8 +2,6 @@ package com.igloo_club.nungil_v3.domain;
 
 import com.igloo_club.nungil_v3.domain.enums.Question;
 import com.igloo_club.nungil_v3.domain.enums.QuestionCategory;
-import com.igloo_club.nungil_v3.dto.QuestionAndAnswerCreateRequest;
-import com.igloo_club.nungil_v3.dto.QuestionAndAnswerUpdateRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,24 +38,14 @@ public class QuestionAndAnswer {
     @Builder.Default
     private Long exposureOrder = null;
 
-    // == 정적 생성 메서드 == //
-    public static QuestionAndAnswer create(QuestionAndAnswerCreateRequest request, Member member){
-        return QuestionAndAnswer.builder()
-                .member(member)
-                .question(request.getQuestion())
-                .questionCategory(request.getQuestion().getCategory())
-                .answer(request.getAnswer())
-                .exposureOrder(request.getExposureOrder())
-                .build();
-    }
 
     // == 비즈니스 메서드 == //
     public void updateOrderToNull(){
         this.exposureOrder = null;
     }
 
-    public void update(QuestionAndAnswerUpdateRequest request){
-        this.answer = request.getAnswer();
-        this.exposureOrder = request.getExposureOrder();
+    public void update(String answer, Long exposureOrder){
+        this.answer = answer;
+        this.exposureOrder = exposureOrder;
     }
 }

--- a/src/main/java/com/igloo_club/nungil_v3/domain/QuestionAndAnswer.java
+++ b/src/main/java/com/igloo_club/nungil_v3/domain/QuestionAndAnswer.java
@@ -1,0 +1,63 @@
+package com.igloo_club.nungil_v3.domain;
+
+import com.igloo_club.nungil_v3.domain.enums.Question;
+import com.igloo_club.nungil_v3.domain.enums.QuestionCategory;
+import com.igloo_club.nungil_v3.dto.QuestionAndAnswerCreateRequest;
+import com.igloo_club.nungil_v3.dto.QuestionAndAnswerUpdateRequest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuestionAndAnswer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(columnDefinition = "VARCHAR(255)")
+    @Enumerated(value = EnumType.STRING)
+    private Question question;
+
+    @Column(columnDefinition = "VARCHAR(20)")
+    @Enumerated(value = EnumType.STRING)
+    private QuestionCategory questionCategory;
+
+    @Column(columnDefinition = "VARCHAR(255)")
+    private String answer;
+
+    @Column(columnDefinition = "TINYINT UNSIGNED")
+    @Builder.Default
+    private Long exposureOrder = null;
+
+    // == 정적 생성 메서드 == //
+    public static QuestionAndAnswer create(QuestionAndAnswerCreateRequest request, Member member){
+        return QuestionAndAnswer.builder()
+                .member(member)
+                .question(request.getQuestion())
+                .questionCategory(request.getQuestion().getCategory())
+                .answer(request.getAnswer())
+                .exposureOrder(request.getExposureOrder())
+                .build();
+    }
+
+    // == 비즈니스 메서드 == //
+    public void updateOrderToNull(){
+        this.exposureOrder = null;
+    }
+
+    public void update(QuestionAndAnswerUpdateRequest request){
+        this.answer = request.getAnswer();
+        this.exposureOrder = request.getExposureOrder();
+    }
+}

--- a/src/main/java/com/igloo_club/nungil_v3/domain/enums/Question.java
+++ b/src/main/java/com/igloo_club/nungil_v3/domain/enums/Question.java
@@ -1,0 +1,30 @@
+package com.igloo_club.nungil_v3.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Question {
+    LIFESTYLE1("나는 아침형 인간 VS 저녁형 인간",QuestionCategory.LIFESTYLE, 1),
+    LIFESTYLE2("주말에는 역시 돌아다니기 VS 집에 있기", QuestionCategory.LIFESTYLE, 2),
+    LIFESTYLE3("나의 평일 일과를 알려주세요.", QuestionCategory.LIFESTYLE, 3),
+    FINANCE1("결혼을 한다면 경제권은 누가 가져야 할까요?", QuestionCategory.FINANCE, 1),
+    FINANCE2("자산은 어떻게 운영 중이실까요?", QuestionCategory.FINANCE, 2),
+    FINANCE3("안정적인 결혼 가능하신가요?", QuestionCategory.FINANCE, 3),
+    FINANCE4("한달에 얼마나 지출하고 저축하시나요?", QuestionCategory.FINANCE, 4),
+    HOUSEWORK1("어떤 방식의 육아를 선호하시나요?", QuestionCategory.HOUSEWORK, 1),
+    HOUSEWORK2("자녀계획 있으세요?", QuestionCategory.HOUSEWORK, 2),
+    HOUSEWORK3("가사는 어떻게 분담 하는 걸 선호 하시나요?", QuestionCategory.HOUSEWORK, 3),
+    VISION1("일과 가정이 양립할 수 없다면 나는?",  QuestionCategory.VISION, 1),
+    VISION2("미래 계획이 어떻게 되세요? 10년 내 목표를 말씀해주세요 (결혼, 출산, 육아, 커리어 전부 상관 없어요)", QuestionCategory.VISION, 2),
+    VISION3("무슨 일 하고 계세요?", QuestionCategory.VISION, 3),
+    FAMILY1("부모님 노후준비가 돼있으실까요?", QuestionCategory.FAMILY, 1),
+    FAMILY2("형제 분들에 대해 애기해주세요.", QuestionCategory.FAMILY, 2),
+    FAMILY3("부모님이 개입이 심하신 편일까요?", QuestionCategory.FAMILY, 3),
+    ;
+    private final String title;
+    private final QuestionCategory category;
+    private final Integer sortNum;
+
+}

--- a/src/main/java/com/igloo_club/nungil_v3/domain/enums/QuestionCategory.java
+++ b/src/main/java/com/igloo_club/nungil_v3/domain/enums/QuestionCategory.java
@@ -1,0 +1,16 @@
+package com.igloo_club.nungil_v3.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionCategory {
+    LIFESTYLE("LIFESTYLE"),
+    FINANCE("FINANCE"),
+    HOUSEWORK("HOUSEWORK"),
+    VISION("VISION"),
+    FAMILY("FAMILY"),
+    ;
+    private final String title;
+}

--- a/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerCreateRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerCreateRequest.java
@@ -1,0 +1,23 @@
+package com.igloo_club.nungil_v3.dto;
+
+import com.igloo_club.nungil_v3.domain.enums.Question;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuestionAndAnswerCreateRequest {
+    @NotNull
+    private Question question;
+
+    @NotNull
+    @Size(max = 255)
+    private String answer;
+
+    private Long exposureOrder;
+}

--- a/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerCreateRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerCreateRequest.java
@@ -1,5 +1,7 @@
 package com.igloo_club.nungil_v3.dto;
 
+import com.igloo_club.nungil_v3.domain.Member;
+import com.igloo_club.nungil_v3.domain.QuestionAndAnswer;
 import com.igloo_club.nungil_v3.domain.enums.Question;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,4 +22,23 @@ public class QuestionAndAnswerCreateRequest {
     private String answer;
 
     private Long exposureOrder;
+
+    // == 정적 생성 메서드 == //
+    public static QuestionAndAnswer create(QuestionAndAnswerCreateRequest request, Member member){
+        return QuestionAndAnswer.builder()
+                .member(member)
+                .question(request.getQuestion())
+                .questionCategory(request.getQuestion().getCategory())
+                .answer(request.getAnswer())
+                .exposureOrder(request.getExposureOrder())
+                .build();
+    }
+
+    public void update(QuestionAndAnswerUpdateRequest request){
+        this.answer = request.getAnswer();
+        this.exposureOrder = request.getExposureOrder();
+    }
+
 }
+
+

--- a/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerResponse.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerResponse.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionAndAnswerResponse {
-    private Long QaId;
+    private Long qaId;
 
     private Question question;
 
@@ -19,7 +19,7 @@ public class QuestionAndAnswerResponse {
 
     public static QuestionAndAnswerResponse create(QuestionAndAnswer qa){
         QuestionAndAnswerResponse response = new QuestionAndAnswerResponse();
-        response.QaId = qa.getId();
+        response.qaId = qa.getId();
         response.question = qa.getQuestion();
         response.answer = qa.getAnswer();
         response.exposureOrder = qa.getExposureOrder();

--- a/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerResponse.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerResponse.java
@@ -1,0 +1,29 @@
+package com.igloo_club.nungil_v3.dto;
+
+import com.igloo_club.nungil_v3.domain.QuestionAndAnswer;
+import com.igloo_club.nungil_v3.domain.enums.Question;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionAndAnswerResponse {
+    private Long QaId;
+
+    private Question question;
+
+    private String answer;
+
+    private Long exposureOrder;
+
+    public static QuestionAndAnswerResponse create(QuestionAndAnswer qa){
+        QuestionAndAnswerResponse response = new QuestionAndAnswerResponse();
+        response.QaId = qa.getId();
+        response.question = qa.getQuestion();
+        response.answer = qa.getAnswer();
+        response.exposureOrder = qa.getExposureOrder();
+
+        return response;
+    }
+}

--- a/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerUpdateRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/QuestionAndAnswerUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.igloo_club.nungil_v3.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuestionAndAnswerUpdateRequest {
+    @NotNull
+    @Size(max = 255)
+    private String answer;
+
+    private Long exposureOrder;
+}

--- a/src/main/java/com/igloo_club/nungil_v3/dto/QuestionListResponse.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/QuestionListResponse.java
@@ -1,0 +1,25 @@
+package com.igloo_club.nungil_v3.dto;
+
+import com.igloo_club.nungil_v3.domain.enums.Question;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionListResponse {
+
+    private Question question;
+
+    private Boolean answered;
+
+    public static QuestionListResponse create(Question question, List<Question> answeredQuestion){
+        QuestionListResponse response = new QuestionListResponse();
+        response.question = question;
+        response.answered = answeredQuestion.contains(question);
+
+        return response;
+    }
+}

--- a/src/main/java/com/igloo_club/nungil_v3/exception/QuestionAndAnswerErrorResult.java
+++ b/src/main/java/com/igloo_club/nungil_v3/exception/QuestionAndAnswerErrorResult.java
@@ -1,0 +1,15 @@
+package com.igloo_club.nungil_v3.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionAndAnswerErrorResult implements ErrorResult{
+    WRONG_ID(HttpStatus.BAD_REQUEST, "Question and answer id is not valid"),
+    WRONG_QUESTION(HttpStatus.BAD_REQUEST, "Question is not answered or valid"),
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/igloo_club/nungil_v3/exception/QuestionAndAnswerErrorResult.java
+++ b/src/main/java/com/igloo_club/nungil_v3/exception/QuestionAndAnswerErrorResult.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum QuestionAndAnswerErrorResult implements ErrorResult{
     WRONG_ID(HttpStatus.BAD_REQUEST, "Question and answer id is not valid"),
     WRONG_QUESTION(HttpStatus.BAD_REQUEST, "Question is not answered or valid"),
+    ANSWERED_QUESTION(HttpStatus.BAD_REQUEST, "Question is already answered"),
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/igloo_club/nungil_v3/repository/QuestionAndAnswerRepository.java
+++ b/src/main/java/com/igloo_club/nungil_v3/repository/QuestionAndAnswerRepository.java
@@ -1,0 +1,27 @@
+package com.igloo_club.nungil_v3.repository;
+
+import com.igloo_club.nungil_v3.domain.Member;
+import com.igloo_club.nungil_v3.domain.QuestionAndAnswer;
+import com.igloo_club.nungil_v3.domain.enums.Question;
+import com.igloo_club.nungil_v3.domain.enums.QuestionCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QuestionAndAnswerRepository extends JpaRepository<QuestionAndAnswer, Long> {
+    Slice<QuestionAndAnswer> findAllByMemberAndExposureOrderBetween(Member member, Long start, Long end);
+
+    Optional<QuestionAndAnswer> findQuestionAndAnswerById(Long id);
+
+    Optional<QuestionAndAnswer> findQuestionAndAnswerByMemberAndQuestion(Member member, Question question);
+
+    Optional<QuestionAndAnswer> findByMemberAndExposureOrder(Member member, Long exposureOrder);
+
+    List<QuestionAndAnswer> findAllByMemberAndQuestionCategory(Member member, QuestionCategory category);
+
+
+}

--- a/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
+++ b/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
@@ -92,9 +92,9 @@ public class QuestionAndAnswerService {
      *
      * @return QuestionAndAnswerResponse 객체
      */
-    public QuestionAndAnswerResponse getQuestionAndAnswerResponseByMemberAndQuestion(Member member, Question question){
-        QuestionAndAnswer qa = questionAndAnswerRepository.findQuestionAndAnswerByMemberAndQuestion(member, question)
-                .orElseThrow(()->new GeneralException(QuestionAndAnswerErrorResult.WRONG_QUESTION));
+    public QuestionAndAnswerResponse getQuestionAndAnswerResponseByMemberAndQuestion(Long qaId){
+        QuestionAndAnswer qa = questionAndAnswerRepository.findQuestionAndAnswerById(qaId)
+                .orElseThrow(()-> new GeneralException(QuestionAndAnswerErrorResult.WRONG_ID));
 
         return QuestionAndAnswerResponse.create(qa);
     }

--- a/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
+++ b/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
@@ -126,7 +126,7 @@ public class QuestionAndAnswerService {
         // 다음 페이지 존재 여부 확인
         boolean hasNext = questionAndAnswerPage.hasNext();
 
-        // 변환된 DTO 리스트와 함께 새로운 Page 객체를 생성하여 반환
+        // 변환된 DTO 리스트와 함께 새로운 Slice 객체를 생성하여 반환
         return new SliceImpl<>(questionAndAnswerResponse, pageRequest, hasNext);
     }
 

--- a/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
+++ b/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
@@ -28,7 +28,7 @@ public class QuestionAndAnswerService {
     private final QuestionAndAnswerRepository questionAndAnswerRepository;
 
     /**
-     * 질의응답을 생성하는 메소드입니다
+     * 신규 질의응답을 생성하는 메소드입니다
      * @param request 질의응답 생성 요청 DTO
      * @param member 질의응답 생성하는 회원
      */
@@ -37,6 +37,11 @@ public class QuestionAndAnswerService {
         // 신규 질의 응답 객체 생성
         QuestionAndAnswer qa = QuestionAndAnswer.create(request, member);
         Long order = request.getExposureOrder();
+
+        // DB를 조회해 기존 질의응답 객체 존재할 시 예외 처리
+        if(questionAndAnswerRepository.findQuestionAndAnswerByMemberAndQuestion(member, request.getQuestion()).isPresent()){
+            throw  new GeneralException(QuestionAndAnswerErrorResult.ANSWERED_QUESTION);
+        }
 
         // 신규 질의 응답과 노출 순서 중복 여부 확인
         // 중복 있을 시 기존 질의 응답 노출 순서 null로 변경

--- a/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
+++ b/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
@@ -148,22 +148,28 @@ public class QuestionAndAnswerService {
                 .map(QuestionAndAnswer::getQuestion)
                 .collect(Collectors.toList());
 
-        // QuestionListResponse로 변환
-        List<QuestionListResponse> questionListResponses = Arrays.stream(Question.values())
-                .map(q-> QuestionListResponse.create(q, answeredQuestion))
+        List<Question> questionList = Arrays.stream(Question.values())
+                .filter(value -> value.getCategory().equals(category))
                 .collect(Collectors.toList());
 
         // 현재 페이지의 시작 인덱스 계산
         int start = Math.toIntExact(pageRequest.getOffset());
-        int end = Math.min((start + pageRequest.getPageSize()), questionListResponses.size());
-
-        // 현재 페이지에 해당하는 리스트 추출
-        List<QuestionListResponse> currentSlice = questionListResponses.subList(start, end);
+        int end = Math.min((start + pageRequest.getPageSize()), questionList.size());
 
         // 다음 페이지가 있는지 여부를 판단
-        boolean hasNext = end < questionListResponses.size();
+        boolean hasNext = end < questionList.size();
 
-        return new SliceImpl<>(currentSlice, pageRequest, hasNext);
+        // 현재 페이지에 해당하는 리스트 추출
+        questionList = questionList.subList(start, end);
+
+        // QuestionListResponse로 변환
+        List<QuestionListResponse> questionListResponses = questionList.stream()
+                .map(q-> QuestionListResponse.create(q, answeredQuestion))
+                .collect(Collectors.toList());
+
+
+
+        return new SliceImpl<>(questionListResponses, pageRequest, hasNext);
     }
 
 

--- a/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
+++ b/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
@@ -35,7 +35,7 @@ public class QuestionAndAnswerService {
     @Transactional
     public void createQuestionAndAnswer(QuestionAndAnswerCreateRequest request, Member member){
         // 신규 질의 응답 객체 생성
-        QuestionAndAnswer qa = QuestionAndAnswer.create(request, member);
+        QuestionAndAnswer qa = QuestionAndAnswerCreateRequest.create(request, member);
         Long order = request.getExposureOrder();
 
         // DB를 조회해 기존 질의응답 객체 존재할 시 예외 처리
@@ -66,7 +66,7 @@ public class QuestionAndAnswerService {
         // 중복 있을 시 기존 질의 응답 노출 순서 null로 변경
         handleExposureOrderConflict(member, request.getExposureOrder());
 
-        qa.update(request);
+        qa.update(request.getAnswer(), request.getExposureOrder());
     }
 
     /**

--- a/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
+++ b/src/main/java/com/igloo_club/nungil_v3/service/QuestionAndAnswerService.java
@@ -1,0 +1,166 @@
+package com.igloo_club.nungil_v3.service;
+
+import com.igloo_club.nungil_v3.domain.Member;
+import com.igloo_club.nungil_v3.domain.QuestionAndAnswer;
+import com.igloo_club.nungil_v3.domain.enums.Question;
+import com.igloo_club.nungil_v3.domain.enums.QuestionCategory;
+import com.igloo_club.nungil_v3.dto.QuestionAndAnswerCreateRequest;
+import com.igloo_club.nungil_v3.dto.QuestionAndAnswerResponse;
+import com.igloo_club.nungil_v3.dto.QuestionAndAnswerUpdateRequest;
+import com.igloo_club.nungil_v3.dto.QuestionListResponse;
+import com.igloo_club.nungil_v3.exception.GeneralException;
+import com.igloo_club.nungil_v3.exception.QuestionAndAnswerErrorResult;
+import com.igloo_club.nungil_v3.repository.QuestionAndAnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class QuestionAndAnswerService {
+    private final QuestionAndAnswerRepository questionAndAnswerRepository;
+
+    /**
+     * 질의응답을 생성하는 메소드입니다
+     * @param request 질의응답 생성 요청 DTO
+     * @param member 질의응답 생성하는 회원
+     */
+    @Transactional
+    public void createQuestionAndAnswer(QuestionAndAnswerCreateRequest request, Member member){
+        // 신규 질의 응답 객체 생성
+        QuestionAndAnswer qa = QuestionAndAnswer.create(request, member);
+        Long order = request.getExposureOrder();
+
+        // 신규 질의 응답과 노출 순서 중복 여부 확인
+        // 중복 있을 시 기존 질의 응답 노출 순서 null로 변경
+        handleExposureOrderConflict(member, order);
+
+        // 신규 질의 응답 저장
+        questionAndAnswerRepository.save(qa);
+    }
+
+    /**
+     * 주어진 질의응답의 정보를 수정하는 메소드입니다
+     * @param member 질의응답을 수정할 멤버
+     * @param qaId 등록된 질의응답 id
+     * @param request 질의응답 수정 요청 DTO
+     */
+    @Transactional
+    public void updateQuestionAndAnswer(Long qaId, QuestionAndAnswerUpdateRequest request, Member member){
+        QuestionAndAnswer qa = questionAndAnswerRepository.findQuestionAndAnswerById(qaId)
+                        .orElseThrow(()-> new GeneralException(QuestionAndAnswerErrorResult.WRONG_ID));
+
+        // 신규 질의 응답과 노출 순서 중복 여부 확인
+        // 중복 있을 시 기존 질의 응답 노출 순서 null로 변경
+        handleExposureOrderConflict(member, request.getExposureOrder());
+
+        qa.update(request);
+    }
+
+    /**
+     * 노출 순서 중복을 처리하는 메소드입니다
+     * 중복이 있을 경우 기존 질의응답의 노출 순서를 null로 업데이트합니다
+     *
+     * @param member 질의응답을 생성하는 회원
+     * @param order 노출 순서
+     */
+    private void handleExposureOrderConflict(Member member, Long order) {
+        if (order != null) {
+            Optional<QuestionAndAnswer> existingQa = questionAndAnswerRepository.findByMemberAndExposureOrder(member, order);
+
+            existingQa.ifPresent(originalQa -> originalQa.updateOrderToNull());
+        }
+    }
+
+    /**
+     * 작성된 단일 질의응답을 조회하는 메소드입니다.
+     *
+     * @param member 질의응답을 조회할 멤버
+     * @param question 질문
+     *
+     * @return QuestionAndAnswerResponse 객체
+     */
+    public QuestionAndAnswerResponse getQuestionAndAnswerResponseByMemberAndQuestion(Member member, Question question){
+        QuestionAndAnswer qa = questionAndAnswerRepository.findQuestionAndAnswerByMemberAndQuestion(member, question)
+                .orElseThrow(()->new GeneralException(QuestionAndAnswerErrorResult.WRONG_QUESTION));
+
+        return QuestionAndAnswerResponse.create(qa);
+    }
+
+
+    /**
+     * 특정 멤버의 전시 중인 질의응답들을 Slice로 조회하는 메소드입니다
+     *
+     * @param member 질의응답을 조회할 멤버
+     * @param page 가져올 페이지 번호
+     * @param size 페이지당 요소 수
+     *
+     * @return QuestionAndAnswerResponse의 페이지 객체
+     */
+    public Slice<QuestionAndAnswerResponse> getExposingQuestionAndAnswerPageByMember(Member member, int page, int size) {
+
+        // pageRequest를 exposureOrder 순으로 생성
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("exposureOrder").ascending());
+
+        // 특정 멤버와 노출 순서 범위로 QuestionAndAnswer 엔티티를 데이터베이스에서 조회
+        Slice<QuestionAndAnswer> questionAndAnswerPage = questionAndAnswerRepository
+                .findAllByMemberAndExposureOrderBetween(member, 0L, (long)size -1);
+
+        // QuestionAndAnswer 엔티티를 QuestionAndAnswer DTO로 변환
+        List<QuestionAndAnswerResponse> questionAndAnswerResponse = questionAndAnswerPage.getContent().stream()
+                .map(QuestionAndAnswerResponse::create)
+                .collect(Collectors.toList());
+
+        // 다음 페이지 존재 여부 확인
+        boolean hasNext = questionAndAnswerPage.hasNext();
+
+        // 변환된 DTO 리스트와 함께 새로운 Page 객체를 생성하여 반환
+        return new SliceImpl<>(questionAndAnswerResponse, pageRequest, hasNext);
+    }
+
+    /**
+     * 특정 카테고리의 질문들을 Slice로 답변 여부와 함께 조회하는 메소드입니다
+     *
+     * @param member 질문을 조회할 멤버
+     * @param page 가져올 페이지 번호
+     * @param size 페이지당 요소 수
+     *
+     * @return QuestionListResponse 슬라이스 객체
+     */
+    public Slice<QuestionListResponse> getQuestionList(Member member, QuestionCategory category, int page, int size){
+        // pageRequest 생성
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("sortNum").ascending());
+
+        // 특정 멤버와 카테고리에 해당하는 질의응답을 조회
+        List<Question> answeredQuestion = questionAndAnswerRepository.findAllByMemberAndQuestionCategory(member, category).stream()
+                .map(QuestionAndAnswer::getQuestion)
+                .collect(Collectors.toList());
+
+        // QuestionListResponse로 변환
+        List<QuestionListResponse> questionListResponses = Arrays.stream(Question.values())
+                .map(q-> QuestionListResponse.create(q, answeredQuestion))
+                .collect(Collectors.toList());
+
+        // 현재 페이지의 시작 인덱스 계산
+        int start = Math.toIntExact(pageRequest.getOffset());
+        int end = Math.min((start + pageRequest.getPageSize()), questionListResponses.size());
+
+        // 현재 페이지에 해당하는 리스트 추출
+        List<QuestionListResponse> currentSlice = questionListResponses.subList(start, end);
+
+        // 다음 페이지가 있는지 여부를 판단
+        boolean hasNext = end < questionListResponses.size();
+
+        return new SliceImpl<>(currentSlice, pageRequest, hasNext);
+    }
+
+
+
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #7 

## 💜 작업 내용

- [x] 신규 질의응답 생성
- [x] 질의응답 수정
- [x] 단일 질의응답 조회
- [x] 특정 멤버의 전시 중인 질의응답을 slice로 조회하는 메소드
- [x] 특정 카테고리 질문들을 slice로 답변 여부와 함께 조회하는 메소드

내부 메소드
- [x] 질의 응답 중복 처리
## ✅ PR Point

1. 신규 질의응답 생성 메소드

    1. 신규 `질의 응답` 객체 생성
    2. DB 조회해 기존 `질의응답 `객체 존재 시(같은 `member`와 `question` 객체를 이용해 조회) 예외 처리
    3. 신규 `질의 응답`과 `노출 순서` 중복 여부 확인 후 중복되는 `노출 순서`의 `질의응답 `존재 시에 기존 `질의 응답` `노출 순서`를 null로 변경
    4. 신규 `질의 응답 `저장
```
    @Transactional
    public void createQuestionAndAnswer(QuestionAndAnswerCreateRequest request, Member member){
        // 신규 질의 응답 객체 생성
        QuestionAndAnswer qa = QuestionAndAnswer.create(request, member);
        Long order = request.getExposureOrder();

        // DB를 조회해 기존 질의응답 객체 존재할 시 예외 처리
        if(questionAndAnswerRepository.findQuestionAndAnswerByMemberAndQuestion(member, request.getQuestion()).isPresent()){
            throw  new GeneralException(QuestionAndAnswerErrorResult.ANSWERED_QUESTION);
        }

        // 신규 질의 응답과 노출 순서 중복 여부 확인
        // 중복 있을 시 기존 질의 응답 노출 순서 null로 변경
        handleExposureOrderConflict(member, order);

        // 신규 질의 응답 저장
        questionAndAnswerRepository.save(qa);
    }

```
2. 질의응답 정보 수정 메소드

    1. 파라미터 변수인 `qa id`에 해당되는 `질의응답 `객체가 존재하지 않을 시 예외 처리
    2. 신규 `질의 응답`과 `노출 순서` 중복 여부 확인 후 중복되는 `노출 순서`의 `질의 응답 `존재 시에 기존 `질의 응답` `노출 순서`를 `null`로 변경
    3. 수정된 `질의 응답` 저장
```
    @Transactional
    public void updateQuestionAndAnswer(Long qaId, QuestionAndAnswerUpdateRequest request, Member member){
        QuestionAndAnswer qa = questionAndAnswerRepository.findQuestionAndAnswerById(qaId)
                        .orElseThrow(()-> new GeneralException(QuestionAndAnswerErrorResult.WRONG_ID));

        // 신규 질의 응답과 노출 순서 중복 여부 확인
        // 중복 있을 시 기존 질의 응답 노출 순서 null로 변경
        handleExposureOrderConflict(member, request.getExposureOrder());

        qa.update(request);
    }

```
3. 단일 질의응답 조회

    1. 파라미터 변수인 `member`와 `question` 객체에 해당하는 `질의응답` 객체 존재하지 않을 시 예외 처리
    2. `QuestionAndAnswerResponse `객체 반환

```
    public QuestionAndAnswerResponse getQuestionAndAnswerResponseByMemberAndQuestion(Member member, Question question){
        QuestionAndAnswer qa = questionAndAnswerRepository.findQuestionAndAnswerByMemberAndQuestion(member, question)
                .orElseThrow(()->new GeneralException(QuestionAndAnswerErrorResult.WRONG_QUESTION));

        return QuestionAndAnswerResponse.create(qa);
    }
```

4. 특정 멤버의 전시 중인 질의응답을 slice로 조회하는 메소드

    해당 메소드는 현재 요구조건 상 `질의응답` 3개인 자료구조만을 반환하면 되지만 요구조건 변경을 고려하여 `Slice`객체로 반환하게끔 구성했습니다.

    1. 특정 `멤버`와 `노출 순서` 범위로 `QuestionAndAnswer `엔티티를 데이터베이스에서 조회
    2. `QuestionAndAnswerResponse `DTO 리스트와 함께 새로운 `Slice `객체를 생성해 반환

```
    public Slice<QuestionAndAnswerResponse> getExposingQuestionAndAnswerPageByMember(Member member, int page, int size) {

        // pageRequest를 exposureOrder 순으로 생성
        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("exposureOrder").ascending());

        // 특정 멤버와 노출 순서 범위로 QuestionAndAnswer 엔티티를 데이터베이스에서 조회
        Slice<QuestionAndAnswer> questionAndAnswerPage = questionAndAnswerRepository
                .findAllByMemberAndExposureOrderBetween(member, 0L, (long)size -1);

        // QuestionAndAnswer 엔티티를 QuestionAndAnswer DTO로 변환
        List<QuestionAndAnswerResponse> questionAndAnswerResponse = questionAndAnswerPage.getContent().stream()
                .map(QuestionAndAnswerResponse::create)
                .collect(Collectors.toList());

        // 다음 페이지 존재 여부 확인
        boolean hasNext = questionAndAnswerPage.hasNext();

        // 변환된 DTO 리스트와 함께 새로운 Slice 객체를 생성하여 반환
        return new SliceImpl<>(questionAndAnswerResponse, pageRequest, hasNext);
    }
```

5. 특정 카테고리 질문들을 slice로 답변 여부와 함께 조회하는 메소드

    질문들은 프론트에서 관리하고 `질문 enum`만 맞추는 것으로 처음에는 설계했습니다.
    해당 방식을 이용 시에 `질문`리스트 조회는 서버를 통하지 않고 프론트측에서 정적으로 관리할 수 있다는 장점이 존재합니다.
    하지만 이러한 방식은 추후 질문이 변경되거나 추가될 때 `질문 enum`을 프론트 측과 다시 맞춰야한다는 단점이 존재했습니다.
    따라서 요구조건 수정에 용이하게 대응하기 위해 `질문 enum`을 백엔드에서 관리함으로써 프론트 측에서는 해당 메소드를 통해 `질문 `리스트를 조회할 수 있게끔 하여 `질문 enum`에 대한 책임을 백엔드에서 온전히 가질 수 있게끔 구성했습니다. 

    1. 특정 `멤버`와 `카테고리`에 해당하는 `질의응답`을 조회
    2. `QuestionListResponse`로 변환(1번에서 `질의응답 `리스트를 이용해 답변 여부 판별)
    4. `QuestionListResponse `DTO 리스트와 함께 새로운 `Slice `객체를 생성해 반환

```
    public Slice<QuestionListResponse> getQuestionList(Member member, QuestionCategory category, int page, int size){
        // pageRequest 생성
        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("sortNum").ascending());

        // 특정 멤버와 카테고리에 해당하는 질의응답을 조회
        List<Question> answeredQuestion = questionAndAnswerRepository.findAllByMemberAndQuestionCategory(member, category).stream()
                .map(QuestionAndAnswer::getQuestion)
                .collect(Collectors.toList());

        // QuestionListResponse로 변환
        List<QuestionListResponse> questionListResponses = Arrays.stream(Question.values())
                .map(q-> QuestionListResponse.create(q, answeredQuestion))
                .collect(Collectors.toList());

        // 현재 페이지의 시작 인덱스 계산
        int start = Math.toIntExact(pageRequest.getOffset());
        int end = Math.min((start + pageRequest.getPageSize()), questionListResponses.size());

        // 현재 페이지에 해당하는 리스트 추출
        List<QuestionListResponse> currentSlice = questionListResponses.subList(start, end);

        // 다음 페이지가 있는지 여부를 판단
        boolean hasNext = end < questionListResponses.size();

        return new SliceImpl<>(currentSlice, pageRequest, hasNext);
    }
```

6. 질의 응답 중복 처리(내부 메소드)
    
    `노출 순서`가 중복된 `질의 응답`이 존재 시에 기존 `질의 응답` `노출 순서`를 `null`로 업데이트함으로써 전시 중인 `질의응답`에 노출되지 않게끔 합니다.

```
    private void handleExposureOrderConflict(Member member, Long order) {
        if (order != null) {
            Optional<QuestionAndAnswer> existingQa = questionAndAnswerRepository.findByMemberAndExposureOrder(member, order);

            existingQa.ifPresent(originalQa -> originalQa.updateOrderToNull());
        }
    }
```



