### PR TITLE
회사 및 프로필 등록 API 스웨거 추가

### DIFF
--- a/src/main/java/com/igloo_club/nungil_v3/controller/CompanyController.java
+++ b/src/main/java/com/igloo_club/nungil_v3/controller/CompanyController.java
@@ -7,6 +7,12 @@ import com.igloo_club.nungil_v3.dto.CompanyRegisterRequest;
 import com.igloo_club.nungil_v3.dto.CompanyVerificationRequest;
 import com.igloo_club.nungil_v3.service.CompanyService;
 import com.igloo_club.nungil_v3.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +22,7 @@ import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Company", description = "Company API")
 public class CompanyController {
 
     private final CompanyService companyService;
@@ -27,6 +34,21 @@ public class CompanyController {
      * @param request 회사 이메일이 포함된 DTO
      */
     @PostMapping("/api/company/email")
+    @Operation(summary = "회사 인증메일 발송", description = "전달 받은 회사 이메일로 인증 확인 메일을 보내는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400_UNAVAILABLE_EMAIL", description = "사용이 불가능한 이메일(e.g. gmail.com)인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"UNAVAILABLE_EMAIL\", \"message\": \"Given email is not available\"}"))),
+            @ApiResponse(responseCode = "400_DUPLICATED_EMAIL", description = "이미 회원가입을 마친 이메일이 존재하는 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"DUPLICATED_EMAIL\", \"message\": \"Given email is already in use\"}"))),
+            @ApiResponse(responseCode = "400_ALREADY_USING", description = "이미 회원가입을 마친 이메일이 본인의 것인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"ALREADY_USING\", \"message\": \"You are already using this email\"}"))),
+            @ApiResponse(responseCode = "500_MESSAGING_EXCEPTION", description = "이메일 전송 중 에러 발생",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"MESSAGING_EXCEPTION\", \"message\": \"Problem occurered when sending email\"}"))),
+    })
     public ResponseEntity<?> sendAuthEmail(@RequestBody CompanyEmailRequest request, Principal principal) {
         Member member = getMember(principal);
 
@@ -41,6 +63,24 @@ public class CompanyController {
      * @param principal 회원 정보가 담긴 Principal 객체
      */
     @PostMapping("/api/company/verification")
+    @Operation(summary = "회사 인증번호 검증", description = "인증번호가 유효한지 검증하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400_UNAVAILABLE_EMAIL", description = "사용이 불가능한 이메일(e.g. gmail.com)인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"UNAVAILABLE_EMAIL\", \"message\": \"Given email is not available\"}"))),
+            @ApiResponse(responseCode = "400_DUPLICATED_EMAIL", description = "이미 회원가입을 마친 이메일이 존재하는 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"DUPLICATED_EMAIL\", \"message\": \"Given email is already in use\"}"))),
+            @ApiResponse(responseCode = "400_ALREADY_USING", description = "이미 회원가입을 마친 이메일이 본인의 것인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"ALREADY_USING\", \"message\": \"You are already using this email\"}"))),
+            @ApiResponse(responseCode = "400_REDIS_NOT_FOUND", description = "요청된 회사 이메일에 대한 인증번호가 없거나 만료된 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"REDIS_NOT_FOUND\", \"message\": \"The requested data is not available or has expired\"}"))),
+            @ApiResponse(responseCode = "400_WRONG_AUTH_CODE", description = "주어진 인증번호가 틀린 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"WRONG_AUTH_CODE\", \"message\": \"The provided authentication code is incorrect\"}"))),
+    })
     public ResponseEntity<?> verifyAuthCode(@RequestBody CompanyVerificationRequest request, Principal principal) {
         Member member = getMember(principal);
 
@@ -55,12 +95,31 @@ public class CompanyController {
      * @return 회사명 목록
      */
     @GetMapping("/api/company")
-    public ResponseEntity<CompanyListResponse> getCompanyList(@RequestParam String email) {
+    @Operation(summary = "회사명 조회", description = "전달받은 이메일에 해당하는 회사명 리스트를 조회하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CompanyListResponse.class))),
+            @ApiResponse(responseCode = "400_UNAVAILABLE_EMAIL", description = "사용이 불가능한 이메일(e.g. gmail.com)인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"UNAVAILABLE_EMAIL\", \"message\": \"Given email is not available\"}"))),
+    })
+    public ResponseEntity<CompanyListResponse> getCompanyList(
+            @Parameter(description = "회사 이메일 혹은 도메인 주소", example = "soongsil.ac.kr")
+                @RequestParam String email) {
         CompanyListResponse companyList = companyService.getCompanyList(email);
         return ResponseEntity.ok(companyList);
     }
 
     @PostMapping("/api/company")
+    @Operation(summary = "회사명 등록", description = "사용자에게 회사명을 등록하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400_UNAVAILABLE_EMAIL", description = "사용이 불가능한 이메일(e.g. gmail.com)인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"UNAVAILABLE_EMAIL\", \"message\": \"Given email is not available\"}"))),
+            @ApiResponse(responseCode = "400_UNAUTHENTICATED_EMAIL", description = "이메일 검증 API에서 인증된 이메일과 다른 이메일로 요청을 보낸 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"UNAUTHENTICATED_EMAIL\", \"message\": \"Given email is not authenticated\"}"))),
+    })
     public ResponseEntity<?> registerCompany(@RequestBody CompanyRegisterRequest request, Principal principal) {
         Member member = getMember(principal);
 

--- a/src/main/java/com/igloo_club/nungil_v3/controller/MemberController.java
+++ b/src/main/java/com/igloo_club/nungil_v3/controller/MemberController.java
@@ -4,8 +4,12 @@ import com.igloo_club.nungil_v3.domain.Member;
 import com.igloo_club.nungil_v3.dto.*;
 import com.igloo_club.nungil_v3.service.CompanyService;
 import com.igloo_club.nungil_v3.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +18,7 @@ import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Member", description = "Member API")
 public class MemberController {
 
     private final MemberService memberService;
@@ -21,6 +26,12 @@ public class MemberController {
     private final CompanyService companyService;
 
     @PostMapping("/api/member/essential")
+    @Operation(summary = "필수 프로필 등록", description = "사용자 필수 프로필 정보를 전달받아 등록하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404_USER_NOT_FOUND", description = "사용자 조회 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"404_USER_NOT_FOUND\", \"message\": \"Failed to find the User\"}"))),
+    })
     public ResponseEntity<?> createEssentialProfile(@RequestBody EssentialProfileCreateRequest request, Principal principal) {
         Member member = getMember(principal);
 
@@ -30,6 +41,12 @@ public class MemberController {
     }
 
     @PostMapping("/api/member/additional")
+    @Operation(summary = "상세 프로필 등록", description = "사용자 상세 프로필 정보를 전달받아 등록하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404_USER_NOT_FOUND", description = "사용자 조회 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"404_USER_NOT_FOUND\", \"message\": \"Failed to find the User\"}"))),
+    })
     public ResponseEntity<?> createAdditionalProfile(@RequestBody AdditionalProfileCreateRequest request, Principal principal) {
         Member member = getMember(principal);
 
@@ -41,6 +58,12 @@ public class MemberController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @Operation(summary = "근무지 등록", description = "근무지를 회원 정보에 등록하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404_USER_NOT_FOUND", description = "사용자 조회 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"404_USER_NOT_FOUND\", \"message\": \"Failed to find the User\"}"))),
+    })
     @PostMapping("/api/member/location")
     public ResponseEntity<?> createLocation(@RequestBody LocationCreateRequest request, Principal principal) {
         Member member = getMember(principal);

--- a/src/main/java/com/igloo_club/nungil_v3/controller/MemberController.java
+++ b/src/main/java/com/igloo_club/nungil_v3/controller/MemberController.java
@@ -76,6 +76,15 @@ public class MemberController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @Operation(summary = "선호 이상 등록", description = "선호 이상을 등록하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400_IDEAL_AGE_PARADOX", description = "이상형의 preferredAgeStart > preferredAgeEnd 인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"IDEAL_AGE_PARADOX\", \"message\": \"Ideal age start is bigger than end\"}"))),
+            @ApiResponse(responseCode = "400_IDEAL_HEIGHT_PARADOX", description = "이상형의 preferredHeightStart> preferredHeightEnd인 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"IDEAL_HEIGHT_PARADOX\", \"message\": \"Ideal height start is bigger than end\"}"))),
+    })
     @PostMapping("/api/member/ideal")
     public ResponseEntity<?> createIdeal(@RequestBody IdealCreateRequest request, Principal principal) {
         Member member = getMember(principal);
@@ -85,6 +94,12 @@ public class MemberController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @Operation(summary = "선호 이상 조회", description = "선호 이상을 조회하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400_IDEAL_NOT_FOUND", description = "이상형이 존재하지 않을 경우",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"code\": \"IDEAL_NOT_FOUND\", \"message\": \"Failed to find the Ideal\"}"))),
+    })
     @GetMapping("/api/member/ideal")
     public ResponseEntity<IdealResponse> getIdeal(Principal principal) {
 
@@ -95,7 +110,9 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
-
+    @Operation(summary = "이미지 업로드 Presigned URL 발급", description = "이미지 업로드를 위한 URL을 발급하는 API 입니다. 이미지 확장자는 `png` 고정입니다.\n성공 시 응답 값의 URL로, 이미지 파일과 함께 `PUT` 요청을 보내면 됩니다.\n만약 PUT 요청이 성공/실패한 경우, 반드시 업로드 완료 알림 API를 호출해주세요.", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/api/member/images")
     public ResponseEntity<?> getImageUploadUrl(Principal principal) {
         Member member = getMember(principal);
@@ -105,6 +122,9 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "이미지 업로드 완료 알림", description = "Presigned URL을 통한 이미지 업로드 성공, 혹은 실패에 대해 서버에 알려주는 API입니다.\n이미지 업로드 Presigned URL 발급 API를 통해 발급받은 Presigned URL을 사용한 이후에 반드시 그 결과를 알려주세요!", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @PostMapping("/api/member/images/notify")
     public ResponseEntity<?> notifyImageUpload(@RequestBody ImageUploadNotifyRequest request, Principal principal) {
         Member member = getMember(principal);
@@ -114,6 +134,9 @@ public class MemberController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @Operation(summary = "본인 프로필 조회", description = "API 요청자의 프로필을 조회하는 API", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+    })
     @GetMapping("/api/member")
     public ResponseEntity<?> getMemberProfile(Principal principal) {
         Member member = getMember(principal);

--- a/src/main/java/com/igloo_club/nungil_v3/controller/QuestionAndAnswerController.java
+++ b/src/main/java/com/igloo_club/nungil_v3/controller/QuestionAndAnswerController.java
@@ -8,6 +8,7 @@ import com.igloo_club.nungil_v3.dto.QuestionAndAnswerUpdateRequest;
 import com.igloo_club.nungil_v3.dto.QuestionListResponse;
 import com.igloo_club.nungil_v3.service.MemberService;
 import com.igloo_club.nungil_v3.service.QuestionAndAnswerService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ import java.security.Principal;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/questions")
+@Tag(name = "QnA", description = "QnA API")
 public class QuestionAndAnswerController {
 
     private final QuestionAndAnswerService questionAndAnswerService;

--- a/src/main/java/com/igloo_club/nungil_v3/dto/AdditionalProfileCreateRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/AdditionalProfileCreateRequest.java
@@ -2,6 +2,8 @@ package com.igloo_club.nungil_v3.dto;
 
 import com.igloo_club.nungil_v3.domain.Profile;
 import com.igloo_club.nungil_v3.domain.enums.*;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -13,28 +15,44 @@ import java.util.List;
 @NoArgsConstructor(force = true)
 @RequiredArgsConstructor
 public class AdditionalProfileCreateRequest {
+
+    @Schema(description = "키", example = "180")
     private final Integer height;
 
+    @Schema(description = "종교", example = "BUDDHISM")
     private final Religion religion;
 
+    @Schema(description = "문신 여부", example = "true")
     private final Boolean tattoo;
 
+    @Schema(description = "흡연 여부", example = "false")
     private final Boolean smoke;
 
+    @Schema(description = "결혼 계획", example = "7")
     private final Integer marriagePlan;
 
+    @Schema(description = "MBTI", example = "ISFP")
     private final MbtiType mbtiType;
 
+    @Schema(description = "세전 연봉", example = "4")
     private final Integer grossSalary;
 
+    @Schema(description = "직무", example = "개발자")
     private final String job;
 
+    @ArraySchema(schema = @Schema(description = "근무 형태", example = "ROTATIONAL"))
     private final List<WorkArrangement> workArrangementList = new ArrayList<>();
 
+    @Schema(description = "회사 규모", example = "MID")
     private final CompanyScale scale;
 
+    @Schema(description = "취미 목록", implementation = HobbyRequest.class,
+            example = "[{\"category\": \"EXERCISE\", \"name\": \"SWIMMING\" }," +
+                    "{\"category\": \"MUSIC\", \"name\": \"INDIE\" }," +
+                    "{\"category\": \"MUSIC\", \"name\": \"BAND\" }]")
     private final List<HobbyRequest> hobbyList = new ArrayList<>();
 
+    @Schema(description = "한 줄 자기소개", example = "수영을 좋아하는 수영입니다")
     private final String intro;
 
     public Profile toProfile() {
@@ -59,7 +77,11 @@ public class AdditionalProfileCreateRequest {
     @Getter
     @NoArgsConstructor
     private static class HobbyRequest {
+
+        @Schema(description = "큰 카테고리", example = "EXERCISE")
         private HobbyCategory category;
+
+        @Schema(description = "작은 카테고리", example = "SWIMMING")
         private HobbyName name;
     }
 }

--- a/src/main/java/com/igloo_club/nungil_v3/dto/CompanyEmailRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/CompanyEmailRequest.java
@@ -1,5 +1,6 @@
 package com.igloo_club.nungil_v3.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,5 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CompanyEmailRequest {
+
+    @Schema(description = "회사 이메일", example = "soo@soongsil.ac.kr")
     private String email;
 }

--- a/src/main/java/com/igloo_club/nungil_v3/dto/CompanyListResponse.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/CompanyListResponse.java
@@ -1,5 +1,7 @@
 package com.igloo_club.nungil_v3.dto;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,12 +10,16 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "회사명 조회 응답")
 public class CompanyListResponse {
 
+    @Schema(description = "도메인 주소", example = "soongsil.ac.kr")
     private String domain;
 
+    @ArraySchema(schema = @Schema(description = "회사명 리스트", example = "숭실대학교"))
     private List<String> companyNameList;
 
+    @Schema(description = "회사명 개수", example = "1")
     private Integer totalCount;
 
     // == 생성 메서드 == //

--- a/src/main/java/com/igloo_club/nungil_v3/dto/CompanyRegisterRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/CompanyRegisterRequest.java
@@ -1,5 +1,6 @@
 package com.igloo_club.nungil_v3.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CompanyRegisterRequest {
+
+    @Schema(description = "회사 이메일", example = "soo@soongsil.ac.kr")
     private String email;
+
+    @Schema(description = "회사명", example = "숭실대학교")
     private String companyName;
 }

--- a/src/main/java/com/igloo_club/nungil_v3/dto/CompanyVerificationRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/CompanyVerificationRequest.java
@@ -1,5 +1,6 @@
 package com.igloo_club.nungil_v3.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CompanyVerificationRequest {
 
+    @Schema(description = "인증번호 6자리", example = "123456")
     private String code;
 
+    @Schema(description = "회사 이메일", example = "soo@soongsil.ac.kr")
     private String email;
 }

--- a/src/main/java/com/igloo_club/nungil_v3/dto/EssentialProfileCreateRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/EssentialProfileCreateRequest.java
@@ -3,6 +3,7 @@ package com.igloo_club.nungil_v3.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.igloo_club.nungil_v3.domain.enums.Sex;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,13 +17,16 @@ import java.time.LocalDate;
 public class EssentialProfileCreateRequest {
     @NotBlank
     @Size(max = 8)
+    @Schema(description = "닉네임", example = "하늘소")
     private String nickname;
 
     @NotNull
+    @Schema(description = "성별", example = "MALE")
     private Sex sex;
 
     @NotNull
     @Past
     @JsonFormat(pattern = "yyyyMMdd")
+    @Schema(description = "생년월일", example = "20001026")
     private LocalDate birthdate;
 }

--- a/src/main/java/com/igloo_club/nungil_v3/dto/ImageUploadNotifyRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/ImageUploadNotifyRequest.java
@@ -1,15 +1,22 @@
 package com.igloo_club.nungil_v3.dto;
 
 import com.igloo_club.nungil_v3.domain.enums.ImageStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
 public class ImageUploadNotifyRequest {
+
+    @NotNull
+    @Schema(description = "업로드한 파일명", example = "9c7f7afe-c95f-4c11-a025-233974c57c9a")
     private UUID filename;
 
+    @NotNull
+    @Schema(description = "업로드 상태", example = "UPLOAD_COMPLETE")
     private ImageStatus status;
 }

--- a/src/main/java/com/igloo_club/nungil_v3/dto/LocationCreateRequest.java
+++ b/src/main/java/com/igloo_club/nungil_v3/dto/LocationCreateRequest.java
@@ -1,6 +1,7 @@
 package com.igloo_club.nungil_v3.dto;
 
 import com.igloo_club.nungil_v3.domain.enums.Location;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -13,5 +14,6 @@ import javax.validation.constraints.NotNull;
 public class LocationCreateRequest {
 
     @NotNull
+    @Schema(description = "근무지", example = "PANGYO")
     private final Location location;
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #10

## 💜 작업 내용

- [x] 회사 등록 API에 스웨거 애노테이션 추가
- [x] 프로필 등록 API에 스웨거 애노테이션 추가

## ✅ PR Point

API와 요청, 응답 데이터에 대한 설명과 예시를 추가했습니다.
또한 `responseCode`의 경우 중복이 불가능했기 때문에, `[상태코드]_[에러코드]`와 같은 형식으로 보여지도록 했습니다.

본래 아래의 `@ApiResponse` 애노테이션에서 중복되는 부분을 줄인 커스텀 애노테이션을 만들려고 했으나, 몇 가지 제한 사항이 있어서 유보했습니다.

```java
@Operation(summary = "회사 인증메일 발송", description = "전달 받은 회사 이메일로 인증 확인 메일을 보내는 API", responses = {
        @ApiResponse(responseCode = "200", description = "성공"),
        @ApiResponse(responseCode = "400_UNAVAILABLE_EMAIL", description = "사용이 불가능한 이메일(e.g. gmail.com)인 경우",
                content = @Content(mediaType = "application/json",
                        schema = @Schema(example = "{\"code\": \"UNAVAILABLE_EMAIL\", \"message\": \"Given email is not available\"}"))),
        @ApiResponse(responseCode = "400_DUPLICATED_EMAIL", description = "이미 회원가입을 마친 이메일이 존재하는 경우",
                content = @Content(mediaType = "application/json",
                        schema = @Schema(example = "{\"code\": \"DUPLICATED_EMAIL\", \"message\": \"Given email is already in use\"}"))),
        @ApiResponse(responseCode = "400_ALREADY_USING", description = "이미 회원가입을 마친 이메일이 본인의 것인 경우",
                content = @Content(mediaType = "application/json",
                        schema = @Schema(example = "{\"code\": \"ALREADY_USING\", \"message\": \"You are already using this email\"}"))),
        @ApiResponse(responseCode = "500_MESSAGING_EXCEPTION", description = "이메일 전송 중 에러 발생",
                content = @Content(mediaType = "application/json",
                        schema = @Schema(example = "{\"code\": \"MESSAGING_EXCEPTION\", \"message\": \"Problem occurered when sending email\"}"))),
})
```

처음에는 아래와 같이, `ErrorResult` 자바 인터페이스를 구현하는 enum 클래스의 값을 받으려 했습니다.

```java
@ApiErrorResponses(
        @ApiErrorResponse(value = CompanyErrorResult.UNAVAILABLE_EMAIL),
        @ApiErrorResponse(value = MemberErrorResult.DUPLICATED_EMAIL),
        @ApiErrorResponse(value = CompanyErrorResult.ALREADY_USING),
        @ApiErrorResponse(value = GlobalErrorResult.MESSAGING_EXCEPTION)
)
```

이를 위해서는 `@ApiErrorResponse` 가, 모든 에러코드 enum 클래스가 구현하는 인터페이스인 `ErrorResult` 타입의 값을 필드로 가져야 했습니다. 하지만, 자바 애노테이션은 인터페이스 타입의 값을 가질 수 없었습니다.

대안으로는 두 가지 방법이 있었습니다.

1. `ErrorResult` 인터페이스 대신, 하나의 공통된 enum 클래스 사용
2. `ErrorResult` 인터페이스 대신, Class<? extends ErrorResult> 사용

### 1. 하나의 공통된 enum 클래스 사용

`GlobalErrorResult`, `MemberErrorResult`, `CompanyErrorResult` 등을 하나의 enum 클래스로 합치고, 해당 enum 클래스를 애노테이션에 사용하는 방법입니다.

단순하고 효과적인 방법이지만, 하나의 클래스에 책임이 집중되는 단점이 있습니다.

### 2. Class<? extends ErrorResult> 사용

특정 enum 값이 아닌, 클래스 자체를 전달받는 방식입니다.

```java
@ApiErrorResponses(
        @ApiErrorResponse(value = CompanyErrorResult.class),
        @ApiErrorResponse(value = MemberErrorResult.class),
        @ApiErrorResponse(value = GlobalErrorResult.class)
)
```

에러 코드를 도메인 별로 분산 시키는 구조를 유지할 수 있습니다.

다만 enum 클래스의 특정 값을 지정하지 못하기 때문에, 각각의 메서드에서 구체적으로 어느 에러가 발생하는지는 드러낼 수 없습니다. ([참고](https://devnm.tistory.com/29))

## ☀ 스크린샷 / GIF / 화면 녹화

![image](https://github.com/user-attachments/assets/ad10dc7c-4bd9-47ea-95f7-35e5c8394c51)


## 📚 Reference

[[Spring Boot 3] SpringDoc과 Swagger를 이용해 API 문서화 자동화하기](https://hogwart-scholars.tistory.com/entry/Spring-Boot-SpringDoc%EA%B3%BC-Swagger%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%B4-API-%EB%AC%B8%EC%84%9C%ED%99%94-%EC%9E%90%EB%8F%99%ED%99%94%ED%95%98%EA%B8%B0)

[[스프링] spring swagger 같은 코드 여러 에러 응답 예시 만들기](https://devnm.tistory.com/29)
